### PR TITLE
Set up userservice protobuf def and  buf module

### DIFF
--- a/.github/workflows/buf-schema-registry-push.yaml
+++ b/.github/workflows/buf-schema-registry-push.yaml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - helloworld
+          - userservice
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -2,6 +2,8 @@ version: v2
 modules:
   - path: helloworld
     name: buf.build/fjarm/helloworld
+  - path: userservice
+    name: buf.build/fjarm/userservice
 deps:
   # NOTE: Keep this version up to date with the pinned version in ../MODULE.bazel
   - buf.build/bufbuild/protovalidate:46a4cf4ba1094a34bcd89a6c67163b4b

--- a/proto/userservice/userservice/v1/BUILD.bazel
+++ b/proto/userservice/userservice/v1/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "user_id_proto",
+    srcs = [
+        "user_id.proto",
+    ],
+    strip_import_prefix = "/proto/userservice",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "@buf_deps//buf/validate:validate_proto",
+    ],
+)

--- a/proto/userservice/userservice/v1/user_id.proto
+++ b/proto/userservice/userservice/v1/user_id.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package userservice.v1;
+
+option go_package = "github.com/fjarm/fjarm/api/internal/pkg/userservice/v1";
+option java_multiple_files = true;
+option java_outer_classname = "UserServiceMessage";
+
+import "buf/validate/validate.proto";
+
+// Unique identifier for a given user.
+message UserId {
+  // Required field that represents the user's unique identifier (UID).
+  // The supplied value must be a UUID as defined by
+  // [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2).
+  optional string user_id = 1[(buf.validate.field).string.uuid = true];
+}


### PR DESCRIPTION
## Summary

This change:

- Defines a Buf module called `userservice` that contains schema definitions related to the User resource and its API
- Creates the `UserId` protobuf message type in the `userservice` module
- Adds `userservice` as an option in the Buf Schema Registry push workflow
