### PR TITLE
Remove unecessary protovalidate-go import in tools

### DIFF
--- a/api/tools/BUILD.bazel
+++ b/api/tools/BUILD.bazel
@@ -7,6 +7,5 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate",
-        "@com_github_bufbuild_protovalidate_go//:protovalidate-go",
     ],
 )

--- a/api/tools/tools.go
+++ b/api/tools/tools.go
@@ -1,6 +1,5 @@
 package tools
 
 import (
-    _ "github.com/bufbuild/protovalidate-go"
-    _ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
+	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 )


### PR DESCRIPTION
## Summary

This change:
- Removes the `_ "github.com/bufbuild/protovalidate-go"` import in the `tools.go` file
- This package is already imported directly in `api/internal/helloworld/service.go`, so it doesn't need to be tools imported
