### PR TITLE
Update Buf GitHub Actions workflows to latest buf-action

### DIFF
--- a/.github/workflows/buf-pull-request.yaml
+++ b/.github/workflows/buf-pull-request.yaml
@@ -24,6 +24,11 @@ jobs:
         name: Run Buf validation
         with:
           version: "1.46.0"
-          push: false
           token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ github.token }}
+          lint: true
+          format: true
+          breaking: true
+          pr_comment: true
+          push: false
+          push_disable_create: true

--- a/.github/workflows/buf-pull-request.yaml
+++ b/.github/workflows/buf-pull-request.yaml
@@ -21,7 +21,7 @@ jobs:
         name: Checkout repo
       # Install the `buf` CLI
       - uses: bufbuild/buf-action@v1
-        name: Install Buf CLI
+        name: Run Buf validation
         with:
           version: "1.46.0"
           push: false

--- a/.github/workflows/buf-pull-request.yaml
+++ b/.github/workflows/buf-pull-request.yaml
@@ -29,6 +29,7 @@ jobs:
           lint: true
           format: true
           breaking: true
+          breaking_against: "https://github.com/fjarm/fjarm.git#branch=main"
           pr_comment: true
           push: false
           push_disable_create: true

--- a/.github/workflows/buf-schema-registry-push.yaml
+++ b/.github/workflows/buf-schema-registry-push.yaml
@@ -1,14 +1,9 @@
 name: Buf Schema Registry push
+permissions:
+  contents: read
+  pull-requests: write
 on:
   workflow_dispatch:
-    inputs:
-      module:
-        description: 'Protobuf module to build and push'
-        required: true
-        type: choice
-        options:
-          - helloworld
-          - userservice
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,28 +11,10 @@ jobs:
       # Run `git checkout`
       - uses: actions/checkout@v4
         name: Checkout repo
-      # Install the `buf` CLI
-      - uses: bufbuild/buf-setup-action@v1
-        name: Install Buf CLI
+      # Install the `buf` CLI, lint and format files, detect breaking changes, and push the latest schema
+      - uses: bufbuild/buf-action@v1
+        name: Run Buf validation and push latest schema
         with:
-          # NOTE: Keep this version up to date with the pinned version in ../../MODULE.bazel
           version: "1.46.0"
+          token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ github.token }}
-          buf_user: ${{ secrets.BUF_USER }}
-          buf_api_token: ${{ secrets.BUF_TOKEN }}
-      - name: Lint all proto files
-        working-directory: ./proto
-        run: |
-          buf lint
-      - name: Detect breaking changes
-        working-directory: ./proto
-        run: |
-          buf breaking --against 'https://github.com/fjarm/fjarm.git#branch=main,subdir=proto'
-      - name: Build module image
-        working-directory: ./proto
-        run: |
-          buf build ${{ inputs.module }}
-      - name: Push module schema
-        working-directory: ./proto
-        run: |
-          buf push ${{ inputs.module }}

--- a/.github/workflows/buf-schema-registry-push.yaml
+++ b/.github/workflows/buf-schema-registry-push.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ github.token }}
           lint: true
-          format: true
+          format: false
           breaking: true
           breaking_against: "https://github.com/fjarm/fjarm.git#branch=main"
           push: true

--- a/.github/workflows/buf-schema-registry-push.yaml
+++ b/.github/workflows/buf-schema-registry-push.yaml
@@ -18,3 +18,8 @@ jobs:
           version: "1.46.0"
           token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ github.token }}
+          lint: true
+          format: true
+          breaking: true
+          push: true
+          push_disable_create: true

--- a/.github/workflows/buf-schema-registry-push.yaml
+++ b/.github/workflows/buf-schema-registry-push.yaml
@@ -21,5 +21,6 @@ jobs:
           lint: true
           format: true
           breaking: true
+          breaking_against: "https://github.com/fjarm/fjarm.git#branch=main"
           push: true
           push_disable_create: true


### PR DESCRIPTION
## Summary

This change updates the Buf PR and BSR push actions by:

- **Rename Buf PR checks lint format breaking step**
- **Use latest buf-action to push to BSR**
- **Specify buf CLI commands to run in workflows**
- **Specify breaking against in buf workflows**
- **Disable buf format in manual BSR push workflow**
