### PR TITLE
Create workflow to push Docker containers to ghcr.io

### DIFF
--- a/.github/workflows/dockerhub-push.yaml
+++ b/.github/workflows/dockerhub-push.yaml
@@ -21,16 +21,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: bazel-contrib/setup-bazel@0.8.5
+      - uses: bazel-contrib/setup-bazel@0.12.1
         name: Install Bazel CLI
         with:
-          # Avoid downloading Bazel every time.
+          # Avoid downloading Bazel every time
           bazelisk-cache: true
-          # Bazelisk version to download and use
           bazelisk-version: 1.x
-          # Store build cache per workflow.
-          disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
+          # Share a single disk cache across workflows
+          disk-cache: true
+          # Enable external repositories caches
+          external-cache: true
+          # Store a single repository cache
           repository-cache: true
       - name: Build all targets under api
         run: |

--- a/.github/workflows/ghcr-push.yaml
+++ b/.github/workflows/ghcr-push.yaml
@@ -1,0 +1,49 @@
+name: GitHub Container Registry push
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Bazel oci_push target to build and push'
+        required: true
+        type: choice
+        options:
+          - helloworld:helloworld_push
+env:
+  REGISTRY: ghcr.io
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      # Run `git checkout`
+      - uses: actions/checkout@v4
+        name: Checkout repo
+      # Log in to the `docker` CLI
+      - uses: docker/login-action@v3
+        name: Log in to the container registry
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: bazel-contrib/setup-bazel@0.12.1
+        name: Install Bazel CLI
+        with:
+          # Avoid downloading Bazel every time
+          bazelisk-cache: true
+          bazelisk-version: 1.x
+          # Share a single disk cache across workflows
+          disk-cache: true
+          # Enable external repositories caches
+          external-cache: true
+          # Store a single repository cache
+          repository-cache: true
+      - name: Build all targets under api
+        run: |
+          bazel build //api/...
+      - name: Run oci_push target
+        run: |
+          bazel run //api/deployment/${{ inputs.module }} --config=release

--- a/.github/workflows/go-pull-request.yaml
+++ b/.github/workflows/go-pull-request.yaml
@@ -15,16 +15,17 @@ jobs:
       # Run `git checkout`
       - uses: actions/checkout@v4
         name: Checkout repo
-      - uses: bazel-contrib/setup-bazel@0.8.5
+      - uses: bazel-contrib/setup-bazel@0.12.1
         name: Install Bazel CLI
         with:
-          # Avoid downloading Bazel every time.
+          # Avoid downloading Bazel every time
           bazelisk-cache: true
-          # Bazelisk version to download and use
           bazelisk-version: 1.x
-          # Store build cache per workflow.
-          disk-cache: ${{ github.workflow }}
-          # Share repository cache between workflows.
+          # Share a single disk cache across workflows
+          disk-cache: true
+          # Enable external repositories caches
+          external-cache: true
+          # Store a single repository cache
           repository-cache: true
       - name: Build all targets under api
         run: |


### PR DESCRIPTION
## Summary

This change creates a GitHub Actions workflow that pushes Docker containers to ghcr.io using Bazel. It also updates other workflows that use the Bazel CLI:

- **Create workflow to push Docker containers to ghcr.io**
- **Update Bazel settings in DockerHub push and Go PR workflows**
