### PR TITLE
Update the repository the helloworld image is pushed to

### DIFF
--- a/api/deployment/helloworld/BUILD.bazel
+++ b/api/deployment/helloworld/BUILD.bazel
@@ -53,7 +53,7 @@ oci_push(
     name = "helloworld_push",
     image = ":helloworld_image_index",
     remote_tags = ":stamped",
-    repository = "index.docker.io/veganafro/helloworld",
+    repository = "ghcr.io/fjarm/helloworld",
 )
 
 oci_load(


### PR DESCRIPTION
## Summary

This change points the helloworld image repository to `ghcr.io` instead of `index.docker.io`
