### PR TITLE
Set up the FullName message in the userservice.v1 package

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ common --enable_bzlmod
 # This also allows us to register toolchains other than com_google_protobuf targets.
 common --incompatible_enable_proto_toolchain_resolution
 
+# SEE: https://github.com/bazel-contrib/bazel-lib/blob/0f5e1dcafd5a27b8ed6ba9805b6d3f59ab8307aa/docs/stamping.md
 # This tells Bazel how to interact with the version control system
 # Enable this with --config=release
 build:release --stamp --workspace_status_command=./tools/bazel_stamp_vars.sh

--- a/api/cmd/helloworld/BUILD.bazel
+++ b/api/cmd/helloworld/BUILD.bazel
@@ -19,6 +19,10 @@ go_binary(
     visibility = ["//visibility:private"],
 )
 
+# SEE: https://go.dev/doc/install/source#environment
+# The valid OS and CPU architecture combinations can be found above.
+# Cross compiled binaries for Linux make sure that local compilation from MacOS doesn't lead to `exec format error`
+# bugs when running the binary inside a Linux container.
 go_cross_binary(
     name = "helloworld_linux_arm64",
     platform = "@rules_go//go/toolchain:linux_arm64",

--- a/api/deployment/helloworld/BUILD.bazel
+++ b/api/deployment/helloworld/BUILD.bazel
@@ -37,6 +37,7 @@ oci_image_index(
     ],
 )
 
+# SEE: https://github.com/bazel-contrib/bazel-lib/blob/fea951508738c95b4d18d93e444101f576458f60/lib/tests/expand_template/BUILD.bazel
 # Use the value of --embed_label under --stamp, otherwise use a deterministic constant
 # value to ensure cache hits for actions that depend on this.
 expand_template(
@@ -49,6 +50,7 @@ expand_template(
     template = "helloworld.tmpl",
 )
 
+# SEE: https://github.com/bazel-contrib/rules_oci/blob/843eb01b152b884fe731a3fb4431b738ad00ea60/docs/push.md
 oci_push(
     name = "helloworld_push",
     image = ":helloworld_image_index",

--- a/proto/helloworld/v1/helloworld.proto
+++ b/proto/helloworld/v1/helloworld.proto
@@ -4,10 +4,11 @@ package helloworld.v1;
 
 import "buf/validate/validate.proto";
 
+// SEE: https://google.aip.dev/191
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/helloworld/v1";
+option java_package = "xyz.fjarm.helloworld.v1";
 option java_multiple_files = true;
-option java_outer_classname = "HelloWorldMessage";
-option java_package = "xyz.fjarm.libhelloworld.gen";
+option java_outer_classname = "HelloworldProto";
 
 message GetHelloWorldRequest {
   string input = 1;

--- a/proto/helloworld/v1/helloworld.proto
+++ b/proto/helloworld/v1/helloworld.proto
@@ -6,9 +6,9 @@ import "buf/validate/validate.proto";
 
 // SEE: https://google.aip.dev/191
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/helloworld/v1";
-option java_package = "xyz.fjarm.helloworld.v1";
 option java_multiple_files = true;
 option java_outer_classname = "HelloworldProto";
+option java_package = "xyz.fjarm.helloworld.v1";
 
 message GetHelloWorldRequest {
   string input = 1;

--- a/proto/helloworld/v1/helloworld_service.proto
+++ b/proto/helloworld/v1/helloworld_service.proto
@@ -6,8 +6,9 @@ import "google/protobuf/empty.proto";
 import "helloworld/v1/helloworld.proto";
 
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/helloworld/v1";
+option java_package = "xyz.fjarm.helloworld.v1";
 option java_multiple_files = true;
-option java_package = "xyz.fjarm.libhelloworld.gen";
+option java_outer_classname = "HelloworldServiceProto";
 
 service HelloWorldService {
   rpc GetHelloWorld(google.protobuf.Empty) returns (helloworld.v1.GetHelloWorldResponse);

--- a/proto/helloworld/v1/helloworld_service.proto
+++ b/proto/helloworld/v1/helloworld_service.proto
@@ -6,9 +6,9 @@ import "google/protobuf/empty.proto";
 import "helloworld/v1/helloworld.proto";
 
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/helloworld/v1";
-option java_package = "xyz.fjarm.helloworld.v1";
 option java_multiple_files = true;
 option java_outer_classname = "HelloworldServiceProto";
+option java_package = "xyz.fjarm.helloworld.v1";
 
 service HelloWorldService {
   rpc GetHelloWorld(google.protobuf.Empty) returns (helloworld.v1.GetHelloWorldResponse);

--- a/proto/userservice/v1/user_full_name.proto
+++ b/proto/userservice/v1/user_full_name.proto
@@ -5,9 +5,9 @@ package userservice.v1;
 import "buf/validate/validate.proto";
 
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/userservice/v1";
-option java_package = "xyz.fjarm.userservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "UserFullNameProto";
+option java_package = "xyz.fjarm.userservice.v1";
 
 // The name a user supplies at registration or later updates. This should be used to address
 // a user in official communications such as emails or push notifications.

--- a/proto/userservice/v1/user_full_name.proto
+++ b/proto/userservice/v1/user_full_name.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package userservice.v1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/fjarm/fjarm/api/internal/pkg/userservice/v1";
+option java_package = "xyz.fjarm.userservice.v1";
+option java_multiple_files = true;
+option java_outer_classname = "UserFullNameProto";
+
+// The name a user supplies at registration or later updates. This should be used to address
+// a user in official communications such as emails or push notifications.
+message FullName {
+  // Required field that represents a user's preferred name when addressing them.
+  optional string family_name = 1 [
+    (buf.validate.field).string.example = "bella",
+    (buf.validate.field).string.min_len = 1,
+    (buf.validate.field).string.max_len = 99
+  ];
+  // Required field that represents a user's family name.
+  optional string given_name = 2 [
+    (buf.validate.field).string.example = "hadid",
+    (buf.validate.field).string.min_len = 1,
+    (buf.validate.field).string.max_len = 99
+  ];
+}

--- a/proto/userservice/v1/user_id.proto
+++ b/proto/userservice/v1/user_id.proto
@@ -5,9 +5,9 @@ package userservice.v1;
 import "buf/validate/validate.proto";
 
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/userservice/v1";
-option java_package = "xyz.fjarm.userservice.v1";
 option java_multiple_files = true;
 option java_outer_classname = "UserIdProto";
+option java_package = "xyz.fjarm.userservice.v1";
 
 // Unique identifier for a given user.
 message UserId {

--- a/proto/userservice/v1/user_id.proto
+++ b/proto/userservice/v1/user_id.proto
@@ -5,8 +5,9 @@ package userservice.v1;
 import "buf/validate/validate.proto";
 
 option go_package = "github.com/fjarm/fjarm/api/internal/pkg/userservice/v1";
+option java_package = "xyz.fjarm.userservice.v1";
 option java_multiple_files = true;
-option java_outer_classname = "UserServiceMessage";
+option java_outer_classname = "UserIdProto";
 
 // Unique identifier for a given user.
 message UserId {


### PR DESCRIPTION
## Summary

This change is mostly concerned with setting up the `FullName` message in the `userservice.v1` package. It also:

- **Document OS x CPU architecture binary cross compilation**
- **Document container labeling with Bazel**
- **Set java_package and java_outer_classname options according to AIP-191 for helloworld.v1**
- **Set java_package and java_outer_classname options according to AIP-191 for UserId message**
- **Set up FullName proto message**
- **Run buf format against all proto files**
