### PR TITLE
Use distroless/static instead of alpine/base for foundation container

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,10 +29,10 @@ use_repo(
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
-    name = "alpine_base",
-    # SEE: https://hub.docker.com/layers/library/alpine/latest/images/sha256-1f390db9d9746cc317e16a98a8be2854c599abcbf04d45b6320b040e72034e33
-    digest = "sha256:b97e2a89d0b9e4011bb88c02ddf01c544b8c781acf1f4d559e7c8f12f1047ac3",
-    image = "docker.io/library/alpine",
+    name = "distroless_static",
+    # SEE: https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/static/sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58
+    digest = "sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58",
+    image = "gcr.io/distroless/static",
     platforms = [
         "linux/amd64",
         "linux/arm64/v8",
@@ -40,9 +40,9 @@ oci.pull(
 )
 use_repo(
     oci,
-    "alpine_base",
-    "alpine_base_linux_amd64",
-    "alpine_base_linux_arm64_v8",
+    "distroless_static",
+    "distroless_static_linux_amd64",
+    "distroless_static_linux_arm64_v8",
 )
 
 register_toolchains("//tools/toolchains:all")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "b7065a21878412a5b337a7521201125ceb730bf11af4ad91493c202e1b95f3a6",
+  "moduleFileHash": "7013223baa6d300f70528c5e22b8bec7777b4360b336557b2c8f9928888d1b03",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -100,18 +100,18 @@
             "column": 20
           },
           "imports": {
-            "alpine_base": "alpine_base",
-            "alpine_base_linux_amd64": "alpine_base_linux_amd64",
-            "alpine_base_linux_arm64_v8": "alpine_base_linux_arm64_v8"
+            "distroless_static": "distroless_static",
+            "distroless_static_linux_amd64": "distroless_static_linux_amd64",
+            "distroless_static_linux_arm64_v8": "distroless_static_linux_arm64_v8"
           },
           "devImports": [],
           "tags": [
             {
               "tagName": "pull",
               "attributeValues": {
-                "name": "alpine_base",
-                "digest": "sha256:b97e2a89d0b9e4011bb88c02ddf01c544b8c781acf1f4d559e7c8f12f1047ac3",
-                "image": "docker.io/library/alpine",
+                "name": "distroless_static",
+                "digest": "sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58",
+                "image": "gcr.io/distroless/static",
                 "platforms": [
                   "linux/amd64",
                   "linux/arm64/v8"
@@ -2618,16 +2618,33 @@
               "crane_version": "v0.18.0"
             }
           },
-          "alpine_base_linux_amd64": {
+          "distroless_static": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_alias",
+            "attributes": {
+              "target_name": "distroless_static",
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58",
+              "platforms": {
+                "@@platforms//cpu:x86_64": "@distroless_static_linux_amd64",
+                "@@platforms//cpu:arm64": "@distroless_static_linux_arm64_v8"
+              },
+              "bzlmod_repository": "distroless_static",
+              "reproducible": true
+            }
+          },
+          "distroless_static_linux_amd64": {
             "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
             "ruleClassName": "oci_pull",
             "attributes": {
               "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/alpine",
-              "identifier": "sha256:b97e2a89d0b9e4011bb88c02ddf01c544b8c781acf1f4d559e7c8f12f1047ac3",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58",
               "platform": "linux/amd64",
-              "target_name": "alpine_base_linux_amd64",
+              "target_name": "distroless_static_linux_amd64",
               "bazel_tags": []
             }
           },
@@ -2816,28 +2833,24 @@
               "platform": "darwin_amd64"
             }
           },
+          "distroless_static_linux_arm64_v8": {
+            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
+            "ruleClassName": "oci_pull",
+            "attributes": {
+              "scheme": "https",
+              "registry": "gcr.io",
+              "repository": "distroless/static",
+              "identifier": "sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58",
+              "platform": "linux/arm64/v8",
+              "target_name": "distroless_static_linux_arm64_v8",
+              "bazel_tags": []
+            }
+          },
           "oci_regctl_linux_amd64": {
             "bzlFile": "@@rules_oci~//oci:repositories.bzl",
             "ruleClassName": "regctl_repositories",
             "attributes": {
               "platform": "linux_amd64"
-            }
-          },
-          "alpine_base": {
-            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
-            "ruleClassName": "oci_alias",
-            "attributes": {
-              "target_name": "alpine_base",
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/alpine",
-              "identifier": "sha256:b97e2a89d0b9e4011bb88c02ddf01c544b8c781acf1f4d559e7c8f12f1047ac3",
-              "platforms": {
-                "@@platforms//cpu:x86_64": "@alpine_base_linux_amd64",
-                "@@platforms//cpu:arm64": "@alpine_base_linux_arm64_v8"
-              },
-              "bzlmod_repository": "alpine_base",
-              "reproducible": true
             }
           },
           "bsd_tar_toolchains": {
@@ -2883,19 +2896,6 @@
               "platform": "linux_armv6"
             }
           },
-          "alpine_base_linux_arm64_v8": {
-            "bzlFile": "@@rules_oci~//oci/private:pull.bzl",
-            "ruleClassName": "oci_pull",
-            "attributes": {
-              "scheme": "https",
-              "registry": "index.docker.io",
-              "repository": "library/alpine",
-              "identifier": "sha256:b97e2a89d0b9e4011bb88c02ddf01c544b8c781acf1f4d559e7c8f12f1047ac3",
-              "platform": "linux/arm64/v8",
-              "target_name": "alpine_base_linux_arm64_v8",
-              "bazel_tags": []
-            }
-          },
           "bazel_features_globals": {
             "bzlFile": "@@bazel_features~//private:globals_repo.bzl",
             "ruleClassName": "globals_repo",
@@ -2928,9 +2928,9 @@
         },
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
-            "alpine_base",
-            "alpine_base_linux_amd64",
-            "alpine_base_linux_arm64_v8"
+            "distroless_static",
+            "distroless_static_linux_amd64",
+            "distroless_static_linux_arm64_v8"
           ],
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",

--- a/api/deployment/helloworld/BUILD.bazel
+++ b/api/deployment/helloworld/BUILD.bazel
@@ -16,15 +16,15 @@ tar(
 )
 
 oci_image(
-    name = "helloworld_alpine_base_linux_amd64",
-    base = "@alpine_base_linux_amd64",
+    name = "helloworld_distroless_static_linux_amd64",
+    base = "@distroless_static_linux_amd64",
     entrypoint = ["api/cmd/helloworld/helloworld_linux_amd64"],
     tars = [":helloworld_linux_amd64_tar"],
 )
 
 oci_image(
-    name = "helloworld_alpine_base_linux_arm64_v8",
-    base = "@alpine_base_linux_arm64_v8",
+    name = "helloworld_distroless_static_linux_arm64_v8",
+    base = "@distroless_static_linux_arm64_v8",
     entrypoint = ["api/cmd/helloworld/helloworld_linux_arm64"],
     tars = [":helloworld_linux_arm64_tar"],
 )
@@ -32,8 +32,8 @@ oci_image(
 oci_image_index(
     name = "helloworld_image_index",
     images = [
-        ":helloworld_alpine_base_linux_amd64",
-        ":helloworld_alpine_base_linux_arm64_v8",
+        ":helloworld_distroless_static_linux_amd64",
+        ":helloworld_distroless_static_linux_arm64_v8",
     ],
 )
 
@@ -61,8 +61,8 @@ oci_push(
 oci_load(
     name = "helloworld_load",
     image = select({
-        "@platforms//cpu:arm64": ":helloworld_alpine_base_linux_arm64_v8",
-        "@platforms//cpu:x86_64": ":helloworld_alpine_base_linux_amd64",
+        "@platforms//cpu:arm64": ":helloworld_distroless_static_linux_arm64_v8",
+        "@platforms//cpu:x86_64": ":helloworld_distroless_static_linux_amd64",
     }),
     repo_tags = ["veganafro/helloworld:local"],
 )


### PR DESCRIPTION
## Summary

This change updates the base container used for applications from `alpine/base` to `distroless/static`.
