### PR TITLE
Add graceful shutdown to helloworld executable

### DIFF
--- a/api/deployment/helloworld/v1/BUILD.bazel
+++ b/api/deployment/helloworld/v1/BUILD.bazel
@@ -55,7 +55,7 @@ oci_push(
     name = "helloworld_push",
     image = ":helloworld_image_index",
     remote_tags = ":stamped",
-    repository = "ghcr.io/fjarm/helloworld",
+    repository = "ghcr.io/fjarm/fjarm/helloworld",
 )
 
 oci_load(


### PR DESCRIPTION
## Summary

This change adds a graceful shutdown to the `helloworld` service's executable. It also updates the container repository path that's pushed to.
