### PR TITLE
Implement and test server interceptor for request ID validation

### DIFF
--- a/api/internal/logkeys/logkeys.go
+++ b/api/internal/logkeys/logkeys.go
@@ -1,9 +1,11 @@
 package logkeys
 
 const Addr = "addr"
+const Duration = "duration"
 const Err = "error"
 const Raw = "raw"
 const Request = "req"
 const Rpc = "rpc"
 const Service = "service"
+const StartTime = "start"
 const Tag = "tag"

--- a/api/internal/tracing/pkg/interceptor/BUILD.bazel
+++ b/api/internal/tracing/pkg/interceptor/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "interceptor",
+    srcs = ["request_id.go"],
+    importpath = "github.com/fjarm/fjarm/api/internal/tracing/pkg/interceptor",
+    visibility = ["//api:__subpackages__"],
+    deps = [
+        "//api/internal/logkeys",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//peer",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "interceptor_test",
+    srcs = ["request_id_test.go"],
+    embed = [":interceptor"],
+    deps = [
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//metadata",
+    ],
+)

--- a/api/internal/tracing/pkg/interceptor/request_id.go
+++ b/api/internal/tracing/pkg/interceptor/request_id.go
@@ -1,0 +1,84 @@
+package interceptor
+
+import (
+	"context"
+	"github.com/fjarm/fjarm/api/internal/logkeys"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+	"log/slog"
+	"time"
+)
+
+// ErrMetadataNotFound is returned when reading the incoming  request context does not have any metadata.
+var ErrMetadataNotFound = status.Error(codes.InvalidArgument, "failed to find metadata")
+
+// ErrRequestIDNotFound is returned when an incoming request does not contain a `request-id` key/value pair.
+var ErrRequestIDNotFound = status.Error(codes.InvalidArgument, "failed to find request-id value")
+
+// RequestIDLoggingInterceptor extracts and logs the incoming gRPC request's `request-id` key/value pair in its
+// metadata.
+func RequestIDLoggingInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		start := time.Now()
+		reqID, err := getRequestID(ctx)
+
+		p, ok := peer.FromContext(ctx)
+		clientIP := "unknown"
+		if ok {
+			clientIP = p.Addr.String()
+		}
+
+		l := slog.LevelInfo
+		if err != nil {
+			l = slog.LevelWarn
+		}
+
+		logger.Log(
+			ctx,
+			l,
+			"intercepted request",
+			slog.String("request-id", reqID),
+			slog.Time(logkeys.StartTime, start),
+			slog.String(logkeys.Addr, clientIP),
+			slog.String(logkeys.Rpc, info.FullMethod),
+			slog.Any(logkeys.Err, err),
+		)
+
+		var res any
+		if err == nil {
+			res, err = handler(ctx, req)
+		}
+		duration := time.Since(start)
+
+		logger.InfoContext(
+			ctx,
+			"completed request",
+			slog.String("request-id", reqID),
+			slog.Duration(logkeys.Duration, duration),
+			slog.Any(logkeys.Err, err),
+		)
+
+		return res, err
+	}
+}
+
+func getRequestID(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", ErrMetadataNotFound
+	}
+
+	values := md.Get("request-id")
+	if len(values) == 0 {
+		return "", ErrRequestIDNotFound
+	}
+
+	if values[0] == "" {
+		return "", ErrRequestIDNotFound
+	}
+
+	return values[0], nil
+}

--- a/api/internal/tracing/pkg/interceptor/request_id_test.go
+++ b/api/internal/tracing/pkg/interceptor/request_id_test.go
@@ -1,0 +1,70 @@
+package interceptor
+
+import (
+	"bytes"
+	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRequestIDLoggingInterceptor_LogOutput(t *testing.T) {
+	dl := slog.Default()
+	defer slog.SetDefault(dl)
+
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, nil))
+
+	slog.SetDefault(l)
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test/method",
+	}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+	si := RequestIDLoggingInterceptor(l)
+
+	tests := map[string]struct {
+		headers  map[string]string
+		expected string
+		err      bool
+	}{
+		"valid_non_empty_request_id": {
+			headers:  map[string]string{"request-id": "abc123"},
+			expected: "INFO msg=\"intercepted request\" request-id=abc123",
+			err:      false,
+		},
+		"invalid_empty_value_request_id": {
+			headers:  map[string]string{"request-id": ""},
+			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			err:      true,
+		},
+		"invalid_empty_request_id": {
+			headers:  map[string]string{},
+			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			err:      true,
+		},
+		"invalid_incorrect_key_request_id": {
+			headers:  map[string]string{"Request-id": "abc123"},
+			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			err:      true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.New(tc.headers))
+			_, err := si(ctx, nil, info, handler)
+			if err != nil && !tc.err {
+				t.Errorf("RequestIDLoggingInterceptor got an unexpected error: %v", err)
+			}
+
+			actual := buf.String()
+			if !strings.Contains(actual, tc.expected) {
+				t.Errorf("RequestIDLoggingInterceptor got: %v, want: %v", actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This change introduces a `grpc.UnaryServerInterceptor` that can be used to verify that each incoming request contains a non-null, non-empty request ID.

If a request with an invalid request ID is received, it is rejected with an error before it can be handled by the `handler`.

Commits:

- **Add timing based log keys**
- **Set up server interceptor for request ID verification**
