### PR TITLE
Set up the users gPRC service skeleton

### DIFF
--- a/api/internal/tracing/pkg/interceptor/request_id.go
+++ b/api/internal/tracing/pkg/interceptor/request_id.go
@@ -12,6 +12,9 @@ import (
 	"time"
 )
 
+// RequestIDKey represents the string used as the key to access the request ID value from the request metadata map.
+const RequestIDKey = "request-id"
+
 // ErrMetadataNotFound is returned when reading the incoming  request context does not have any metadata.
 var ErrMetadataNotFound = status.Error(codes.InvalidArgument, "failed to find metadata")
 
@@ -40,7 +43,7 @@ func RequestIDLoggingInterceptor(logger *slog.Logger) grpc.UnaryServerIntercepto
 			ctx,
 			l,
 			"intercepted request",
-			slog.String("request-id", reqID),
+			slog.String(RequestIDKey, reqID),
 			slog.Time(logkeys.StartTime, start),
 			slog.String(logkeys.Addr, clientIP),
 			slog.String(logkeys.Rpc, info.FullMethod),
@@ -56,7 +59,7 @@ func RequestIDLoggingInterceptor(logger *slog.Logger) grpc.UnaryServerIntercepto
 		logger.InfoContext(
 			ctx,
 			"completed request",
-			slog.String("request-id", reqID),
+			slog.String(RequestIDKey, reqID),
 			slog.Duration(logkeys.Duration, duration),
 			slog.Any(logkeys.Err, err),
 		)
@@ -71,7 +74,7 @@ func getRequestID(ctx context.Context) (string, error) {
 		return "", ErrMetadataNotFound
 	}
 
-	values := md.Get("request-id")
+	values := md.Get(RequestIDKey)
 	if len(values) == 0 {
 		return "", ErrRequestIDNotFound
 	}

--- a/api/internal/users/v1/BUILD.bazel
+++ b/api/internal/users/v1/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "users",
+    srcs = [
+        "domain.go",
+        "grpc_handler.go",
+    ],
+    importpath = "github.com/fjarm/fjarm/api/internal/users/v1",
+    visibility = ["//api:__subpackages__"],
+    deps = [
+        "//api/internal/logkeys",
+        "@build_buf_gen_go_fjarm_fjarm_grpc_go//fjarm/users/v1/usersv1grpc",
+        "@build_buf_gen_go_fjarm_fjarm_protocolbuffers_go//fjarm/users/v1:users",
+        "@com_github_bufbuild_protovalidate_go//:protovalidate-go",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
+	"context"
+)
+
+type domain struct {
+}
+
+func newUserDomain() userDomain {
+	dom := &domain{}
+	return dom
+}
+
+func (dom *domain) createUser(ctx context.Context, user *userspb.User) (*userspb.User, error) {
+	return nil, nil
+}
+
+func (dom *domain) getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error) {
+	return nil, nil
+}

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -20,3 +20,11 @@ func (dom *domain) createUser(ctx context.Context, user *userspb.User) (*userspb
 func (dom *domain) getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error) {
 	return nil, nil
 }
+
+func (dom *domain) updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error) {
+	return nil, nil
+}
+
+func (dom *domain) deleteUser(ctx context.Context, user *userspb.User) error {
+	return nil
+}

--- a/api/internal/users/v1/grpc_handler.go
+++ b/api/internal/users/v1/grpc_handler.go
@@ -1,0 +1,95 @@
+package v1
+
+import (
+	usersrpc "buf.build/gen/go/fjarm/fjarm/grpc/go/fjarm/users/v1/usersv1grpc"
+	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
+	"context"
+	"github.com/bufbuild/protovalidate-go"
+	"github.com/fjarm/fjarm/api/internal/logkeys"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"log/slog"
+)
+
+const handlerTag = "grpc_handler"
+
+// ErrUnimplemented is returned when a service method is called before it's been implemented.
+var ErrUnimplemented = status.Error(codes.Unimplemented, "rpc is not implemented")
+
+type userDomain interface {
+	createUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
+	getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error)
+}
+
+// GrpcHandler implements the gRPC service found in `user_service.proto`.
+type GrpcHandler struct {
+	usersrpc.UnimplementedUserServiceServer
+
+	domain    userDomain
+	logger    *slog.Logger
+	validator protovalidate.Validator
+}
+
+// CreateUser handles gRPC requests to create a `User` entity.
+func (h *GrpcHandler) CreateUser(
+	ctx context.Context,
+	req *userspb.CreateUserRequest,
+) (*userspb.CreateUserResponse, error) {
+	return nil, ErrUnimplemented
+}
+
+// GetUser handles gRPC requests to retrieve a `User` entity.
+func (h *GrpcHandler) GetUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.GetUserResponse, error) {
+	return nil, ErrUnimplemented
+}
+
+// UpdateUser handles gRPC requests to modify a field in a `User` entity.
+func (h *GrpcHandler) UpdateUser(
+	ctx context.Context,
+	req *userspb.UpdateUserRequest,
+) (*userspb.UpdateUserResponse, error) {
+	return nil, ErrUnimplemented
+}
+
+// DeleteUser handles gRPC requests to delete an instance of a `User` entity.
+func (h *GrpcHandler) DeleteUser(
+	ctx context.Context,
+	req *userspb.DeleteUserRequest,
+) (*userspb.DeleteUserResponse, error) {
+	return nil, ErrUnimplemented
+}
+
+// NewGrpcHandler creates a concrete users gRPC service with logging and business/domain logic.
+func NewGrpcHandler(l *slog.Logger) *GrpcHandler {
+	logger := l.With(
+		slog.String(logkeys.Tag, handlerTag),
+	)
+
+	validator, err := protovalidate.New(
+		protovalidate.WithDisableLazy(),
+		protovalidate.WithFailFast(),
+		protovalidate.WithMessages(
+			&userspb.CreateUserRequest{},
+			&userspb.CreateUserResponse{},
+			&userspb.GetUserRequest{},
+			&userspb.GetUserResponse{},
+		),
+	)
+
+	if err != nil {
+		logger.Error(
+			"failed to create message validator",
+			slog.Any(logkeys.Err, err),
+		)
+	}
+
+	dom := newUserDomain()
+
+	handler := GrpcHandler{
+		domain:    dom,
+		logger:    logger,
+		validator: validator,
+	}
+
+	return &handler
+}

--- a/api/internal/users/v1/grpc_handler.go
+++ b/api/internal/users/v1/grpc_handler.go
@@ -19,6 +19,8 @@ var ErrUnimplemented = status.Error(codes.Unimplemented, "rpc is not implemented
 type userDomain interface {
 	createUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
 	getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error)
+	updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
+	deleteUser(ctx context.Context, user *userspb.User) error
 }
 
 // GrpcHandler implements the gRPC service found in `user_service.proto`.


### PR DESCRIPTION
## Summary

This change sets up the skeleton of the `fjarm.users.v1.UserService` gRPC service.

Commits:

- **Export request ID key**
- **Stand up users service gRPC handler**
- **Define remaining update and delete rpcs**
