### PR TITLE
Remove explicit usages of Status proto and gRPC-Go dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,6 @@ use_repo(
     "com_connectrpc_connect",
     "com_github_bufbuild_protovalidate_go",
     "com_github_google_uuid",
-    "org_golang_google_grpc",
     "org_golang_google_protobuf",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "c717761d8108ae648a10aa06e56cab14f5da2f8984b880deadfdc0afa268d2ec",
+  "moduleFileHash": "bcb862cf7fc82d6c711eb115a68a43687424626e71722c027cb40f86547e5e69",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -70,7 +70,6 @@
             "com_connectrpc_connect": "com_connectrpc_connect",
             "com_github_bufbuild_protovalidate_go": "com_github_bufbuild_protovalidate_go",
             "com_github_google_uuid": "com_github_google_uuid",
-            "org_golang_google_grpc": "org_golang_google_grpc",
             "org_golang_google_protobuf": "org_golang_google_protobuf"
           },
           "devImports": [],
@@ -97,7 +96,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 31,
+            "line": 30,
             "column": 20
           },
           "imports": {
@@ -121,7 +120,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 32,
+                "line": 31,
                 "column": 9
               }
             }

--- a/api/internal/helloworld/v1/BUILD.bazel
+++ b/api/internal/helloworld/v1/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "@build_buf_gen_go_fjarm_fjarm_protocolbuffers_go//fjarm/helloworld/v1:helloworld",
         "@com_connectrpc_connect//:connect",
         "@com_github_bufbuild_protovalidate_go//:protovalidate-go",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/api/internal/helloworld/v1/connect_rpc_handler.go
+++ b/api/internal/helloworld/v1/connect_rpc_handler.go
@@ -8,8 +8,6 @@ import (
 	"github.com/bufbuild/protovalidate-go"
 	"github.com/fjarm/fjarm/api/internal/logkeys"
 	"github.com/fjarm/fjarm/api/internal/tracing"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"log/slog"
 )
 
@@ -54,7 +52,6 @@ func (h *ConnectRPCHandler) GetHelloWorld(
 	}
 
 	res := connect.NewResponse(&pb.GetHelloWorldResponse{
-		Status: status.New(codes.OK, codes.OK.String()).Proto(),
 		Output: &pb.HelloWorldOutput{
 			Output: &msg,
 		},

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	connectrpc.com/connect v1.18.1
 	github.com/bufbuild/protovalidate-go v0.9.1
 	github.com/google/uuid v1.6.0
-	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 )
 
@@ -20,7 +19,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3 // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250207221924-e9438ea467c6 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250207221924-e9438ea467c6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/cel-go v0.23.2 h1:UdEe3CvQh3Nv+E/j9r1Y//WO0K0cSyD7/y0bzyLIMI4=
 github.com/google/cel-go v0.23.2/go.mod h1:52Pb6QsDbC5kvgxvZhiL9QX1oZEkcUF/ZqaPx1J5Wwo=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -41,16 +39,12 @@ golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3 h1:qNgPs5exUA+G0C96DrPwNrvLS
 golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 google.golang.org/genproto/googleapis/api v0.0.0-20250207221924-e9438ea467c6 h1:L9JNMl/plZH9wmzQUHleO/ZZDSN+9Gh41wPczNy+5Fk=
 google.golang.org/genproto/googleapis/api v0.0.0-20250207221924-e9438ea467c6/go.mod h1:iYONQfRdizDB8JJBybql13nArx91jcUk7zCXEsOofM4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250207221924-e9438ea467c6 h1:2duwAxN2+k0xLNpjnHTXoMUgnv6VPSp5fiqTuwSxjmI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250207221924-e9438ea467c6/go.mod h1:8BS3B93F/U1juMFq9+EDk+qOT5CO1R9IzXxG3PTqiRk=
-google.golang.org/grpc v1.70.0 h1:pWFv03aZoHzlRKHWicjsZytKAiYCtNS0dHbXnIdq7jQ=
-google.golang.org/grpc v1.70.0/go.mod h1:ofIJqVKDXx/JiXrwr2IG4/zwdH9txy3IlF40RmcJSQw=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

This change removes removes explicit usages of the `Status` well-known-type Protobuf message. This can be done now that ConnectRPC has replaced gRPC and ConnectRPC does not use the `Status` type directly.

The field remains available on messages like `fjarm.helloworld.v1.GetHelloWorldResponse` in case it's needed in the future.

Commits:

- **Remove explicit setting of Status field in GetHelloWorldResponse message**
- **Remove explicit dependency on gRPC-Go**
