### PR TITLE
Last minute clean up before introducing "real" Redis and Postgres

### DIFF
--- a/api/internal/authentication/pkg/v1/salts.go
+++ b/api/internal/authentication/pkg/v1/salts.go
@@ -17,7 +17,7 @@ func generateSalt(size int) (string, error) {
 	if err != nil {
 		// The error is not recoverable and therefore isn't defined in common_errors.go. This should result in a panic
 		// and connect.CodeUnknown being returned to the client.
-		return "", fmt.Errorf("failed to generate salt: %v", err)
+		return "", fmt.Errorf("failed to generate salt: %w", err)
 	}
 
 	// Encode as base64 for safe storage

--- a/api/internal/users/v1/connect_rpc_handler.go
+++ b/api/internal/users/v1/connect_rpc_handler.go
@@ -14,7 +14,7 @@ import (
 const connectRPCHandlerTag = "connect_rpc_handler"
 
 type userDomain interface {
-	createUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
+	createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error)
 	getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error)
 	updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
 	deleteUser(ctx context.Context, user *userspb.User) error
@@ -50,7 +50,7 @@ func (h *ConnectRPCHandler) CreateUser(
 	}
 
 	// Create the user entity.
-	usr, err := h.domain.createUser(ctx, req.Msg.GetUser())
+	usr, err := h.domain.createUser(ctx, req.Msg)
 	if err != nil {
 		logger.ErrorContext(ctx,
 			"failed to create user entity",

--- a/api/internal/users/v1/connect_rpc_handler.go
+++ b/api/internal/users/v1/connect_rpc_handler.go
@@ -15,7 +15,7 @@ const connectRPCHandlerTag = "connect_rpc_handler"
 
 type userDomain interface {
 	createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error)
-	getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error)
+	getUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.User, error)
 	updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
 	deleteUser(ctx context.Context, user *userspb.User) error
 }

--- a/api/internal/users/v1/connect_rpc_handler.go
+++ b/api/internal/users/v1/connect_rpc_handler.go
@@ -16,8 +16,8 @@ const connectRPCHandlerTag = "connect_rpc_handler"
 type userDomain interface {
 	createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error)
 	getUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.User, error)
-	updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error)
-	deleteUser(ctx context.Context, user *userspb.User) error
+	updateUser(ctx context.Context, req *userspb.UpdateUserRequest) (*userspb.User, error)
+	deleteUser(ctx context.Context, req *userspb.DeleteUserRequest) error
 }
 
 // ConnectRPCHandler defines a ConnectRPC handler for the `fjarm.users.v1.UserService` service.

--- a/api/internal/users/v1/connect_rpc_handler.go
+++ b/api/internal/users/v1/connect_rpc_handler.go
@@ -38,17 +38,6 @@ func (h *ConnectRPCHandler) CreateUser(
 	)
 	logger.InfoContext(ctx, "received request to create user")
 
-	// Validate the incoming message.
-	err := h.validator.Validate(req.Msg)
-	if err != nil || req.Msg.GetUserId().GetUserId() != req.Msg.GetUser().GetUserId().GetUserId() {
-		logger.ErrorContext(ctx,
-			"failed to validate incoming request message",
-			slog.String(logkeys.Raw, req.Msg.String()),
-			slog.Any(logkeys.Err, err),
-		)
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-
 	// Create the user entity.
 	usr, err := h.domain.createUser(ctx, req.Msg)
 	if err != nil {
@@ -125,7 +114,7 @@ func NewConnectRPCHandler(l *slog.Logger) *ConnectRPCHandler {
 	}
 
 	rep := newInMemoryRepository(l)
-	dom := newUserDomain(l, rep)
+	dom := newUserDomain(l, rep, validator)
 	han := ConnectRPCHandler{
 		domain:    dom,
 		logger:    l,

--- a/api/internal/users/v1/connect_rpc_handler_test.go
+++ b/api/internal/users/v1/connect_rpc_handler_test.go
@@ -59,6 +59,13 @@ func TestConnectRPCHandler_CreateUser_gRPCClient(t *testing.T) {
 			errs: []bool{false},
 			code: []connect.Code{},
 		},
+		"validation_one_nil_user": {
+			reqs: []*userspb.CreateUserRequest{
+				nil,
+			},
+			errs: []bool{true},
+			code: []connect.Code{connect.CodeInvalidArgument},
+		},
 		"validation_one_no_idempotency_key_user": {
 			reqs: []*userspb.CreateUserRequest{
 				{

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -68,7 +68,7 @@ func (dom *domain) createUser(ctx context.Context, req *userspb.CreateUserReques
 	return &userspb.User{}, nil
 }
 
-func (dom *domain) getUserWithID(ctx context.Context, id *userspb.UserId) (*userspb.User, error) {
+func (dom *domain) getUser(ctx context.Context, req *userspb.GetUserRequest) (*userspb.User, error) {
 	return nil, ErrUnimplemented
 }
 

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -72,10 +72,10 @@ func (dom *domain) getUser(ctx context.Context, req *userspb.GetUserRequest) (*u
 	return nil, ErrUnimplemented
 }
 
-func (dom *domain) updateUser(ctx context.Context, user *userspb.User) (*userspb.User, error) {
+func (dom *domain) updateUser(ctx context.Context, req *userspb.UpdateUserRequest) (*userspb.User, error) {
 	return nil, ErrUnimplemented
 }
 
-func (dom *domain) deleteUser(ctx context.Context, user *userspb.User) error {
+func (dom *domain) deleteUser(ctx context.Context, req *userspb.DeleteUserRequest) error {
 	return ErrUnimplemented
 }

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -4,31 +4,56 @@ import (
 	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/bufbuild/protovalidate-go"
+	"github.com/fjarm/fjarm/api/internal/logkeys"
+	"github.com/fjarm/fjarm/api/internal/tracing"
 	"log/slog"
 )
+
+const domainTag = "domain"
 
 type userRepository interface {
 	createUser(ctx context.Context, user *userspb.User) (*user, error)
 }
 
 type domain struct {
-	logger *slog.Logger
-	repo   userRepository
+	logger    *slog.Logger
+	repo      userRepository
+	validator protovalidate.Validator
 }
 
-func newUserDomain(l *slog.Logger, r userRepository) userDomain {
+func newUserDomain(l *slog.Logger, r userRepository, v protovalidate.Validator) userDomain {
 	dom := &domain{
-		logger: l,
-		repo:   r,
+		logger:    l,
+		repo:      r,
+		validator: v,
 	}
 	return dom
 }
 
 // TODO(2025-02-26): Update the signature to accept a CreateUserRequest instead of a User so idempotency can be handled in the business logic.
 func (dom *domain) createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error) {
+	logger := dom.logger.With(
+		slog.String(logkeys.Tag, domainTag),
+		slog.Any(tracing.RequestIDKey, ctx.Value(tracing.RequestIDKey)),
+	)
+
 	msg := req.GetUser()
 
-	_, err := dom.repo.createUser(ctx, msg)
+	// Validate the incoming message.
+	err := dom.validator.Validate(msg)
+	// The user ID in the request must match the user ID in the user entity.
+	if err != nil || req.GetUserId().GetUserId() != msg.GetUserId().GetUserId() {
+		logger.ErrorContext(ctx,
+			"failed to validate incoming request message",
+			slog.String(logkeys.Raw, redactedUserMessageString(msg)),
+			slog.Any(logkeys.Err, err),
+		)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidArgument, err)
+	}
+
+	_, err = dom.repo.createUser(ctx, msg)
 	if err != nil && errors.Is(err, ErrAlreadyExists) {
 		// User creation is idempotent. But, we don't want to leak this information to the client. So, instead of
 		// returning the error, we return a successful response without the user's details.

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -32,7 +32,7 @@ func newUserDomain(l *slog.Logger, r userRepository, v protovalidate.Validator) 
 	return dom
 }
 
-// TODO(2025-02-26): Update the signature to accept a CreateUserRequest instead of a User so idempotency can be handled in the business logic.
+// TODO(2025-02-27): Idempotency needs to be handled here after Redis-based caching is introduced.
 func (dom *domain) createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error) {
 	logger := dom.logger.With(
 		slog.String(logkeys.Tag, domainTag),

--- a/api/internal/users/v1/domain.go
+++ b/api/internal/users/v1/domain.go
@@ -24,8 +24,11 @@ func newUserDomain(l *slog.Logger, r userRepository) userDomain {
 	return dom
 }
 
-func (dom *domain) createUser(ctx context.Context, user *userspb.User) (*userspb.User, error) {
-	_, err := dom.repo.createUser(ctx, user)
+// TODO(2025-02-26): Update the signature to accept a CreateUserRequest instead of a User so idempotency can be handled in the business logic.
+func (dom *domain) createUser(ctx context.Context, req *userspb.CreateUserRequest) (*userspb.User, error) {
+	msg := req.GetUser()
+
+	_, err := dom.repo.createUser(ctx, msg)
 	if err != nil && errors.Is(err, ErrAlreadyExists) {
 		// User creation is idempotent. But, we don't want to leak this information to the client. So, instead of
 		// returning the error, we return a successful response without the user's details.

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -171,6 +171,78 @@ func TestUserDomain_createUser(t *testing.T) {
 			errs: []bool{false, false},
 			kind: []error{nil, nil},
 		},
+		"idempotency_two_identical_email_users": {
+			// Two identical users with different idempotency keys should pass without error because the internal state
+			// should be hidden from clients.
+			reqs: []*userspb.CreateUserRequest{
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					User: &userspb.User{
+						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper1")},
+						Password:     &userspb.UserPassword{Password: proto.String("password")},
+					},
+				},
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174888"), // Different idempotency key - ends with 888 instead of 999.
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")}, // Different user ID from the one in the request above.
+					User: &userspb.User{
+						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")}, // User ID here matches the user ID in the request message.
+						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+						Password:     &userspb.UserPassword{Password: proto.String("password")},
+					},
+				},
+			},
+			errs: []bool{false, false},
+			kind: []error{nil, nil},
+		},
+		"idempotency_two_identical_handle_users": {
+			// Two identical users with different idempotency keys should pass without error because the internal state
+			// should be hidden from clients.
+			reqs: []*userspb.CreateUserRequest{
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					User: &userspb.User{
+						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo1@bar.com")},
+						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+						Password:     &userspb.UserPassword{Password: proto.String("password")},
+					},
+				},
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174888"), // Different idempotency key - ends with 888 instead of 999.
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")}, // Different user ID from the one in the request above.
+					User: &userspb.User{
+						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")}, // User ID here matches the user ID in the request message.
+						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+						Password:     &userspb.UserPassword{Password: proto.String("password")},
+					},
+				},
+			},
+			errs: []bool{false, false},
+			kind: []error{nil, nil},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -1,11 +1,13 @@
 package v1
 
 import (
+	idempotencypb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/idempotency/v1"
 	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
 	"context"
 	"errors"
 	"github.com/bufbuild/protovalidate-go"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
 	"log/slog"
 	"testing"
@@ -95,7 +97,14 @@ func TestUserDomain_createUser(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			for i, msg := range tc.users {
-				req := &userspb.CreateUserRequest{User: msg}
+				req := &userspb.CreateUserRequest{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String(msg.GetUserId().GetUserId())},
+					User:   msg,
+				}
 				_, err = dom.createUser(context.Background(), req)
 				if err != nil && !tc.errs[i] {
 					t.Errorf("createUser got an unexpected error: %v", err)

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -1,11 +1,13 @@
 package v1
 
 import (
+	idempotencypb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/idempotency/v1"
 	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
 	"context"
 	"errors"
 	"github.com/bufbuild/protovalidate-go"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"io"
 	"log/slog"
 	"testing"
@@ -28,6 +30,11 @@ func TestUserDomain_createUser(t *testing.T) {
 		"validation_one_valid_user": {
 			reqs: []*userspb.CreateUserRequest{
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -96,7 +96,7 @@ func TestUserDomain_createUser(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			for i, msg := range tc.users {
 				req := &userspb.CreateUserRequest{User: msg}
-				_, err := dom.createUser(context.Background(), req)
+				_, err = dom.createUser(context.Background(), req)
 				if err != nil && !tc.errs[i] {
 					t.Errorf("createUser got an unexpected error: %v", err)
 				}

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -50,6 +50,11 @@ func TestUserDomain_createUser(t *testing.T) {
 		"validation_one_no_password_user": {
 			reqs: []*userspb.CreateUserRequest{
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
@@ -65,6 +70,11 @@ func TestUserDomain_createUser(t *testing.T) {
 		"idempotency_two_distinct_valid_users": {
 			reqs: []*userspb.CreateUserRequest{
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
@@ -74,6 +84,11 @@ func TestUserDomain_createUser(t *testing.T) {
 					},
 				},
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4568-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4568-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
@@ -87,17 +102,29 @@ func TestUserDomain_createUser(t *testing.T) {
 			kind: []error{nil, nil},
 		},
 		"idempotency_two_identical_id_users": {
+			// Two identical users with different idempotency keys should pass without error because the internal state
+			// should be hidden from clients.
 			reqs: []*userspb.CreateUserRequest{
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
-						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo1@bar.com")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
 						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
 						Password:     &userspb.UserPassword{Password: proto.String("password")},
 					},
 				},
 				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174888"), // Different idempotency key - ends with 888 instead of 999.
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					User: &userspb.User{
 						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -47,6 +47,40 @@ func TestUserDomain_createUser(t *testing.T) {
 			errs: []bool{false},
 			kind: []error{nil},
 		},
+		"validation_one_nil_user": {
+			reqs: []*userspb.CreateUserRequest{
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					User:   nil, // The User field is required but is nil here.
+				},
+			},
+			errs: []bool{true},
+			kind: []error{ErrInvalidArgument},
+		},
+		"validation_one_mismatched_id_user": {
+			reqs: []*userspb.CreateUserRequest{
+				{
+					IdempotencyKey: &idempotencypb.IdempotencyKey{
+						IdempotencyKey: proto.String("123e4567-e89b-12d3-a456-426614174999"),
+						Timestamp:      timestamppb.Now(),
+					},
+					UserId: &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174555")}, // The User ID here ends in 555, which doesn't match the user ID in the field below.
+					User: &userspb.User{
+						UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+						FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+						EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo1@bar.com")},
+						Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+						Password:     &userspb.UserPassword{Password: proto.String("password")},
+					},
+				},
+			},
+			errs: []bool{true},
+			kind: []error{ErrInvalidArgument},
+		},
 		"validation_one_no_password_user": {
 			reqs: []*userspb.CreateUserRequest{
 				{

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -90,7 +90,8 @@ func TestUserDomain_createUser(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			for i, msg := range tc.users {
-				_, err := dom.createUser(context.Background(), msg)
+				req := &userspb.CreateUserRequest{User: msg}
+				_, err := dom.createUser(context.Background(), req)
 				if err != nil && !tc.errs[i] {
 					t.Errorf("createUser got an unexpected error: %v", err)
 				}

--- a/api/internal/users/v1/domain_test.go
+++ b/api/internal/users/v1/domain_test.go
@@ -4,6 +4,7 @@ import (
 	userspb "buf.build/gen/go/fjarm/fjarm/protocolbuffers/go/fjarm/users/v1"
 	"context"
 	"errors"
+	"github.com/bufbuild/protovalidate-go"
 	"google.golang.org/protobuf/proto"
 	"io"
 	"log/slog"
@@ -13,7 +14,11 @@ import (
 func TestUserDomain_createUser(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	repo := newInMemoryRepository(logger)
-	dom := newUserDomain(logger, repo)
+	validator, err := protovalidate.New()
+	if err != nil {
+		t.Errorf("failed to create a new validator: %v", err)
+	}
+	dom := newUserDomain(logger, repo, validator)
 
 	tests := map[string]struct {
 		users []*userspb.User

--- a/api/internal/users/v1/in_memory_repository.go
+++ b/api/internal/users/v1/in_memory_repository.go
@@ -49,7 +49,16 @@ func (repo *inMemoryRepository) createUser(ctx context.Context, msg *userspb.Use
 		return nil, ErrAlreadyExists
 	}
 
-	// TODO(2025-02-26): If a user entity with the same email address or handle as the message already exists, return an already exists error.
+	// If a user entity with the same email address or handle as the submitted message already exists, return an
+	// already exists error.
+	for _, usr := range repo.database {
+		if usr.EmailAddress == msg.GetEmailAddress().GetEmailAddress() {
+			return nil, ErrAlreadyExists
+		}
+		if usr.Handle == msg.GetHandle().GetHandle() {
+			return nil, ErrAlreadyExists
+		}
+	}
 
 	// At this point, the supplied user message should be valid. Convert the Protobuf message to a storage entity.
 	// Because `wireUserToStorageUser` returns an error if the message is nil, we don't need to check for `nil` here or

--- a/api/internal/users/v1/in_memory_repository.go
+++ b/api/internal/users/v1/in_memory_repository.go
@@ -49,6 +49,8 @@ func (repo *inMemoryRepository) createUser(ctx context.Context, msg *userspb.Use
 		return nil, ErrAlreadyExists
 	}
 
+	// TODO(2025-02-26): If a user entity with the same email address or handle as the message already exists, return an already exists error.
+
 	// At this point, the supplied user message should be valid. Convert the Protobuf message to a storage entity.
 	// Because `wireUserToStorageUser` returns an error if the message is nil, we don't need to check for `nil` here or
 	// elsewhere.

--- a/api/internal/users/v1/in_memory_repository_test.go
+++ b/api/internal/users/v1/in_memory_repository_test.go
@@ -255,7 +255,7 @@ func TestInMemoryRepository_createUser(t *testing.T) {
 					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
 					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
 					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo1@bar.com")},
-					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper1")},
 					Password:     &userspb.UserPassword{Password: proto.String("password")},
 				},
 				{
@@ -280,6 +280,46 @@ func TestInMemoryRepository_createUser(t *testing.T) {
 				},
 				{
 					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+					Password:     &userspb.UserPassword{Password: proto.String("password")},
+				},
+			},
+			err:  []bool{false, true},
+			kind: []error{nil, ErrAlreadyExists},
+		},
+		"idempotency_two_identical_email_users": {
+			users: []*userspb.User{
+				{
+					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper1")},
+					Password:     &userspb.UserPassword{Password: proto.String("password")},
+				},
+				{
+					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")},
+					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
+					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+					Password:     &userspb.UserPassword{Password: proto.String("password")},
+				},
+			},
+			err:  []bool{false, true},
+			kind: []error{nil, ErrAlreadyExists},
+		},
+		"idempotency_two_identical_handle_users": {
+			users: []*userspb.User{
+				{
+					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174000")},
+					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
+					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo1@bar.com")},
+					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},
+					Password:     &userspb.UserPassword{Password: proto.String("password")},
+				},
+				{
+					UserId:       &userspb.UserId{UserId: proto.String("123e4567-e89b-12d3-a456-426614174999")},
 					FullName:     &userspb.UserFullName{GivenName: proto.String("foo"), FamilyName: proto.String("bar")},
 					EmailAddress: &userspb.UserEmailAddress{EmailAddress: proto.String("foo@bar.com")},
 					Handle:       &userspb.UserHandle{Handle: proto.String("gleeper")},


### PR DESCRIPTION
## Summary

This change does some last minute clean up before introducing "real" (in Docker Compose for now) Redis and Postgres.

The changes are mainly refactoring the `userDomain` interface such that its methods accept request messages defined in `fjarm.users.v1` instead of `fjarm.users.v1.User` messages.

This has the benefit of moving tasks like idempotency validation out of the transport/handler layer to the business logic/domain layer.

Also, message validation is similarly moved to the domain layer.

These changes simplify the transport/handler layer such that it can be easier replaced (similar to how the gRPC handler was migrated to ConnectRPC).

Next steps include:
* Implement an interceptor that enforces deliberately ambiguous timing.
* Implement an interceptor that enforces peer based rate limiting.
* Introduce Redis caching for idempotency keys used in mutation operations (create, update, delete) and consistency values like ETags used in all operations.
* Introduce Postgres (high availability with connection pooling) storage for persisting data.
* Implement a registration service two-stage registration.
    * One stage to collect required info like email address, handle, and password.
    * Another stage to collect optional info like full name and avatar then complete registration.
* Finish implementing the rest of the methods in `fjarm.v1.users.UserService`.
