### PR TITLE
Set up ambiguous timing interceptor

### DIFF
--- a/api/cmd/helloworld/v1/BUILD.bazel
+++ b/api/cmd/helloworld/v1/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//api/internal/helloworld/v1:helloworld",
         "//api/internal/logkeys",
+        "//api/internal/obfuscation/pkg",
         "//api/internal/tracing/pkg/interceptor",
         "@build_buf_gen_go_fjarm_fjarm_connectrpc_go//fjarm/helloworld/v1/helloworldv1connect",
         "@com_connectrpc_connect//:connect",

--- a/api/cmd/helloworld/v1/main.go
+++ b/api/cmd/helloworld/v1/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	helloworld "github.com/fjarm/fjarm/api/internal/helloworld/v1"
 	"github.com/fjarm/fjarm/api/internal/logkeys"
+	"github.com/fjarm/fjarm/api/internal/obfuscation/pkg"
 	"github.com/fjarm/fjarm/api/internal/tracing/pkg/interceptor"
 	"log/slog"
 	"net"
@@ -38,7 +39,10 @@ func main() {
 	}
 	addr := fmt.Sprintf("%s:%s", ip, port)
 
-	interceptors := connect.WithInterceptors(interceptor.NewConnectRPCRequestIDLoggingInterceptor(logger))
+	interceptors := connect.WithInterceptors(
+		pkg.NewConnectRPCAmbiguousTimingInterceptor(logger, pkg.DelayDuration_15000ms),
+		interceptor.NewConnectRPCRequestIDLoggingInterceptor(logger),
+	)
 	connectRPCHandler := helloworld.NewConnectRPCHandler(logger)
 	path, handler := helloworldv1connect.NewHelloWorldServiceHandler(connectRPCHandler, interceptors)
 

--- a/api/internal/obfuscation/pkg/BUILD.bazel
+++ b/api/internal/obfuscation/pkg/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pkg",
+    srcs = [
+        "connect_rpc_ambiguous_timing_interceptor.go",
+        "delay_duration.go",
+    ],
+    importpath = "github.com/fjarm/fjarm/api/internal/obfuscation/pkg",
+    visibility = ["//api:__subpackages__"],
+    deps = [
+        "//api/internal/logkeys",
+        "@com_connectrpc_connect//:connect",
+    ],
+)

--- a/api/internal/obfuscation/pkg/BUILD.bazel
+++ b/api/internal/obfuscation/pkg/BUILD.bazel
@@ -21,3 +21,10 @@ go_test(
     embed = [":pkg"],
     deps = ["@com_connectrpc_connect//:connect"],
 )
+
+go_test(
+    name = "pkg_benchmark_test",
+    srcs = ["connect_rpc_ambiguous_timing_interceptor_benchmark_test.go"],
+    embed = [":pkg"],
+    deps = ["@com_connectrpc_connect//:connect"],
+)

--- a/api/internal/obfuscation/pkg/BUILD.bazel
+++ b/api/internal/obfuscation/pkg/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pkg",
@@ -10,6 +10,14 @@ go_library(
     visibility = ["//api:__subpackages__"],
     deps = [
         "//api/internal/logkeys",
+        "//api/internal/tracing",
         "@com_connectrpc_connect//:connect",
     ],
+)
+
+go_test(
+    name = "pkg_test",
+    srcs = ["connect_rpc_ambiguous_timing_interceptor_test.go"],
+    embed = [":pkg"],
+    deps = ["@com_connectrpc_connect//:connect"],
 )

--- a/api/internal/obfuscation/pkg/BUILD.bazel
+++ b/api/internal/obfuscation/pkg/BUILD.bazel
@@ -17,14 +17,10 @@ go_library(
 
 go_test(
     name = "pkg_test",
-    srcs = ["connect_rpc_ambiguous_timing_interceptor_test.go"],
-    embed = [":pkg"],
-    deps = ["@com_connectrpc_connect//:connect"],
-)
-
-go_test(
-    name = "pkg_benchmark_test",
-    srcs = ["connect_rpc_ambiguous_timing_interceptor_benchmark_test.go"],
+    srcs = [
+        "connect_rpc_ambiguous_timing_interceptor_benchmark_test.go",
+        "connect_rpc_ambiguous_timing_interceptor_test.go",
+    ],
     embed = [":pkg"],
     deps = ["@com_connectrpc_connect//:connect"],
 )

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor.go
@@ -24,6 +24,11 @@ func NewConnectRPCAmbiguousTimingInterceptor(l *slog.Logger, dd DelayDuration) c
 			)
 
 			start := time.Now()
+
+			if dd < 0 {
+				logger.WarnContext(ctx, "invalid delay duration", slog.Any("delay", dd))
+				dd = DelayDuration(1000)
+			}
 			// Introduce a random delay between 0 and dd milliseconds (usually 15 seconds).
 			delay := time.Duration(rand.Intn(int(dd))) * time.Millisecond
 

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor.go
@@ -1,0 +1,39 @@
+package pkg
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"fmt"
+	"github.com/fjarm/fjarm/api/internal/logkeys"
+	"log/slog"
+	"math/rand"
+	"time"
+)
+
+const connectRPCAmbiguousTimingInterceptorTag = "connect_rpc_ambiguous_timing_interceptor"
+
+// NewConnectRPCAmbiguousTimingInterceptor creates an interceptor that introduces random delays to requests.
+func NewConnectRPCAmbiguousTimingInterceptor(l *slog.Logger, dd DelayDuration) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			logger := l.With(
+				slog.String(logkeys.Tag, connectRPCAmbiguousTimingInterceptorTag),
+			)
+
+			// Introduce a random delay between 0 and dd milliseconds
+			delay := time.Duration(rand.Intn(int(dd))) * time.Millisecond
+
+			logger.InfoContext(ctx, "introduced ambiguous delay", slog.Duration("delay", delay))
+
+			select {
+			case <-time.After(delay):
+				// Proceed with the next handler after the delay
+				return next(ctx, req)
+			case <-ctx.Done():
+				// Handle context cancellation
+				logger.ErrorContext(ctx, "terminated request", slog.Any("err", ctx.Err()))
+				return nil, connect.NewError(connect.CodeAborted, fmt.Errorf("terminated request"))
+			}
+		}
+	}
+}

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_benchmark_test.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_benchmark_test.go
@@ -1,0 +1,32 @@
+package pkg
+
+import (
+	"bytes"
+	"connectrpc.com/connect"
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func Benchmark_NewConnectRPCAmbiguousTimingInterceptor(b *testing.B) {
+	dl := slog.Default()
+	defer slog.SetDefault(dl)
+
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, nil))
+	slog.SetDefault(l)
+
+	next := func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		res := "a cool response"
+		return connect.NewResponse(&res), nil
+	}
+
+	interceptor := NewConnectRPCAmbiguousTimingInterceptor(l, DelayDuration(1))(next)
+
+	for i := 0; i < b.N; i++ {
+		req := connect.NewRequest(
+			&[]string{"a", "cool", "request"},
+		)
+		_, _ = interceptor(context.Background(), req)
+	}
+}

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
@@ -28,7 +28,7 @@ func TestNewConnectRPCAmbiguousTimingInterceptor_LogOutput(t *testing.T) {
 	}{
 		"valid_delay": {
 			delay:  DelayDuration(1000),
-			output: []string{"level=\"INFO\"", "msg=\"introduced ambiguous delay\"", "delay"},
+			output: []string{"level=INFO", "msg=\"introduced ambiguous delay\"", "delay"},
 		},
 		"invalid_negative_delay": {
 			delay:  DelayDuration(-1),

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
@@ -1,0 +1,37 @@
+package pkg
+
+import (
+	"bytes"
+	"connectrpc.com/connect"
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestNewConnectRPCAmbiguousTimingInterceptor_LogOutput(t *testing.T) {
+	dl := slog.Default()
+	defer slog.SetDefault(dl)
+
+	var buf bytes.Buffer
+	l := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(l)
+
+	next := func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, nil
+	}
+	interceptor := NewConnectRPCAmbiguousTimingInterceptor(l, DelayDuration_15000ms)(next)
+
+	tests := map[string]struct {
+	}{}
+	for name, _ := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := connect.NewRequest(
+				&[]string{"a", "cool", "request"},
+			)
+			_, err := interceptor(context.Background(), req)
+			if err != nil {
+
+			}
+		})
+	}
+}

--- a/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
+++ b/api/internal/obfuscation/pkg/connect_rpc_ambiguous_timing_interceptor_test.go
@@ -19,18 +19,31 @@ func TestNewConnectRPCAmbiguousTimingInterceptor_LogOutput(t *testing.T) {
 	next := func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		return nil, nil
 	}
-	interceptor := NewConnectRPCAmbiguousTimingInterceptor(l, DelayDuration_15000ms)(next)
+	delay := DelayDuration(1)
+	interceptor := NewConnectRPCAmbiguousTimingInterceptor(l, delay)(next)
 
 	tests := map[string]struct {
-	}{}
-	for name, _ := range tests {
+		delay  DelayDuration
+		output []string
+		err    bool
+	}{
+		"valid_delay": {
+			delay:  delay,
+			output: []string{"level=\"INFO\"", "msg=\"introduced ambiguous delay\"", "delay=1000ms"},
+		},
+	}
+	t.Parallel()
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			req := connect.NewRequest(
 				&[]string{"a", "cool", "request"},
 			)
 			_, err := interceptor(context.Background(), req)
-			if err != nil {
-
+			if err != nil && !tc.err {
+				t.Errorf("NewConnectRPCAmbiguousTimingInterceptor got an unexpected error: %v", err)
+			}
+			if err == nil && tc.err {
+				t.Errorf("NewConnectRPCAmbiguousTimingInterceptor expected an error but got none")
 			}
 		})
 	}

--- a/api/internal/obfuscation/pkg/delay_duration.go
+++ b/api/internal/obfuscation/pkg/delay_duration.go
@@ -1,0 +1,9 @@
+package pkg
+
+type DelayDuration int
+
+const (
+	// DelayDuration_15000ms represents a delay of 15000 milliseconds or 15 seconds. 15 seconds is the request timeout
+	// for most clients.
+	DelayDuration_15000ms DelayDuration = 15000
+)

--- a/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor.go
+++ b/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor.go
@@ -12,7 +12,7 @@ import (
 // NewConnectRPCRequestIDLoggingInterceptor intercepts ConnectRPC requests and verifies that a key named `request-id` is
 // in the request headers with a non-null value. If the key can't be found, the request is automatically rejected.
 // Otherwise, the corresponding value is added to the context before completing the request.
-func NewConnectRPCRequestIDLoggingInterceptor(logger *slog.Logger) connect.UnaryInterceptorFunc {
+func NewConnectRPCRequestIDLoggingInterceptor(l *slog.Logger) connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			start := time.Now()
@@ -25,14 +25,17 @@ func NewConnectRPCRequestIDLoggingInterceptor(logger *slog.Logger) connect.Unary
 
 			clientIP := req.Peer().Addr
 
+			logger := l.With(
+				slog.String(tracing.RequestIDKey, reqID),
+				slog.String(logkeys.Addr, clientIP),
+				slog.String(logkeys.Rpc, req.Spec().Procedure),
+			)
+
 			logger.Log(
 				ctx,
 				lvl,
 				"intercepted request",
-				slog.String(tracing.RequestIDKey, reqID),
 				slog.Time(logkeys.StartTime, start),
-				slog.String(logkeys.Addr, clientIP),
-				slog.String(logkeys.Rpc, req.Spec().Procedure),
 				slog.Any(logkeys.Err, err),
 			)
 
@@ -46,7 +49,6 @@ func NewConnectRPCRequestIDLoggingInterceptor(logger *slog.Logger) connect.Unary
 			logger.InfoContext(
 				ctx,
 				"completed request",
-				slog.String(tracing.RequestIDKey, reqID),
 				slog.Duration(logkeys.Duration, duration),
 				slog.Any(logkeys.Err, err),
 			)

--- a/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor.go
+++ b/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const connectRPCRequestIDInterceptorTag = "connect_rpc_request_id_interceptor"
+
 // NewConnectRPCRequestIDLoggingInterceptor intercepts ConnectRPC requests and verifies that a key named `request-id` is
 // in the request headers with a non-null value. If the key can't be found, the request is automatically rejected.
 // Otherwise, the corresponding value is added to the context before completing the request.
@@ -26,6 +28,7 @@ func NewConnectRPCRequestIDLoggingInterceptor(l *slog.Logger) connect.UnaryInter
 			clientIP := req.Peer().Addr
 
 			logger := l.With(
+				slog.String(logkeys.Tag, connectRPCRequestIDInterceptorTag),
 				slog.String(tracing.RequestIDKey, reqID),
 				slog.String(logkeys.Addr, clientIP),
 				slog.String(logkeys.Rpc, req.Spec().Procedure),

--- a/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor_test.go
+++ b/api/internal/tracing/pkg/interceptor/connect_rpc_request_id_interceptor_test.go
@@ -25,27 +25,27 @@ func TestNewConnectRPCRequestIDLoggingInterceptor_LogOutput(t *testing.T) {
 
 	tests := map[string]struct {
 		headers  map[string]string
-		expected string
+		expected []string
 		err      bool
 	}{
 		"valid_non_empty_request_id": {
 			headers:  map[string]string{"request-id": "abc123"},
-			expected: "INFO msg=\"intercepted request\" request-id=abc123",
+			expected: []string{"INFO", "msg=\"intercepted request\"", "request-id=abc123"},
 			err:      false,
 		},
 		"invalid_empty_value_request_id": {
 			headers:  map[string]string{"request-id": ""},
-			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			expected: []string{"WARN", "msg=\"intercepted request\"", "request-id=\"\""},
 			err:      true,
 		},
 		"invalid_empty_request_id": {
 			headers:  map[string]string{},
-			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			expected: []string{"WARN", "msg=\"intercepted request\"", "request-id=\"\""},
 			err:      true,
 		},
 		"invalid_incorrect_key_request_id": {
 			headers:  map[string]string{"Request-id": "abc123"},
-			expected: "WARN msg=\"intercepted request\" request-id=\"\"",
+			expected: []string{"WARN", "msg=\"intercepted request\"", "request-id=\"\""},
 			err:      true,
 		},
 	}
@@ -62,8 +62,10 @@ func TestNewConnectRPCRequestIDLoggingInterceptor_LogOutput(t *testing.T) {
 				t.Errorf("NewConnectRPCRequestIDLoggingInterceptor got an unexpected error: %v", err)
 			}
 			actual := buf.String()
-			if !strings.Contains(actual, tc.expected) {
-				t.Errorf("NewConnectRPCRequestIDLoggingInterceptor got: %v, want: %v", actual, tc.expected)
+			for _, exp := range tc.expected {
+				if !strings.Contains(actual, exp) {
+					t.Errorf("NewConnectRPCRequestIDLoggingInterceptor got: %v, want: %v", actual, tc.expected)
+				}
 			}
 		})
 	}

--- a/api/internal/users/v1/BUILD.bazel
+++ b/api/internal/users/v1/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "@build_buf_gen_go_fjarm_fjarm_protocolbuffers_go//fjarm/idempotency/v1:idempotency",
         "@build_buf_gen_go_fjarm_fjarm_protocolbuffers_go//fjarm/users/v1:users",
         "@com_connectrpc_connect//:connect",
+        "@com_github_bufbuild_protovalidate_go//:protovalidate-go",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/timestamppb",
     ],


### PR DESCRIPTION
## Summary

This change sets up and uses an ambiguous timing interceptor. The interceptor adds a random latency to all requests and is a naive protection against timing attacks.

Next steps include:

* Introduce Redis (high availability) caching for idempotency keys used in mutation operations (create, update, delete) and consistency values like ETags used in all operations.
* Implement an interceptor that enforces peer based rate limiting.
* Introduce Postgres (high availability with connection pooling) storage for persisting data.
* Implement a registration service two-stage registration.
* One stage to collect required info like email address, handle, and password.
* Another stage to collect optional info like full name and avatar then complete registration.
* Finish implementing the rest of the methods in `fjarm.v1.users.UserService`.
