### PR TITLE
Add permissions to GitHub Actions workflows that are missing them

### DIFF
--- a/.github/workflows/android-unit-test-pull-request.yaml
+++ b/.github/workflows/android-unit-test-pull-request.yaml
@@ -1,4 +1,7 @@
 name: Android PR checks
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches:

--- a/.github/workflows/fly-io-deploy.yaml
+++ b/.github/workflows/fly-io-deploy.yaml
@@ -1,4 +1,7 @@
 name: Fly deploy
+permissions:
+  contents: read
+  pull-requests: write
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/go-pull-request.yaml
+++ b/.github/workflows/go-pull-request.yaml
@@ -1,4 +1,7 @@
 name: Go PR checks
+permissions:
+  contents: read
+  pull-requests: write
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

This change adds permissions/restrictions to the GitHub token created for the workflows that are missing them.
