### PR TITLE
Set up VSCode for Bazel rules_go

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,43 @@
+{
+  "editor.rulers": [120],
+  "[markdown]":  {
+    "editor.wordWrap": "off"
+  },
+  "go.goroot": "~/development/fjarm/bazel-fjarm/external/rules_go++go_sdk+fjarm__download_0/",
+  "go.toolsEnvVars": {
+    "GOPACKAGESDRIVER": "~/development/fjarm/scripts/gopackagesdriver.sh"
+  },
+  "go.enableCodeLens": {
+    "runtest": false
+  },
+  "gopls": {
+    "build.workspaceFiles": [
+      "**/BUILD",
+      "**/WORKSPACE",
+      "**/*.{bzl,bazel}"
+    ],
+    "build.directoryFilters": [
+      "-bazel-bin",
+      "-bazel-out",
+      "-bazel-testlogs",
+      "-bazel-fjarm"
+    ],
+    "formatting.gofumpt": true,
+    "formatting.local": "github.com/fjarm/fjarm",
+    "ui.completion.usePlaceholders": true,
+    "ui.semanticTokens": true,
+    "ui.codelenses": {
+      "gc_details": false,
+      "regenerate_cgo": false,
+      "generate": false,
+      "test": false,
+      "tidy": false,
+      "upgrade_dependency": false,
+      "vendor": false
+    }
+  },
+  "go.useLanguageServer": true,
+  "go.buildOnSave": "off",
+  "go.lintOnSave": "off",
+  "go.vetOnSave": "off"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,9 @@
   "[markdown]":  {
     "editor.wordWrap": "off"
   },
-  "go.goroot": "~/development/fjarm/bazel-fjarm/external/rules_go++go_sdk+fjarm__download_0/",
+  "go.goroot": "${env:HOME}/development/fjarm/bazel-fjarm/external/rules_go++go_sdk+fjarm__download_0/",
   "go.toolsEnvVars": {
-    "GOPACKAGESDRIVER": "~/development/fjarm/scripts/gopackagesdriver.sh"
+    "GOPACKAGESDRIVER": "${env:HOME}/development/fjarm/scripts/gopackagesdriver.sh"
   },
   "go.enableCodeLens": {
     "runtest": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,13 @@
       "-bazel-bin",
       "-bazel-out",
       "-bazel-testlogs",
-      "-bazel-fjarm"
+      "-bazel-fjarm",
+      "-.idea",
+      "-.vscode",
+      "-.ijwb",
+      "-android",
+      "-docs",
+      "-proto"
     ],
     "formatting.gofumpt": true,
     "formatting.local": "github.com/fjarm/fjarm",

--- a/scripts/gopackagesdriver.sh
+++ b/scripts/gopackagesdriver.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# See https://github.com/bazelbuild/rules_go/wiki/Editor-setup#3-editor-setup
+exec bazel run -- @rules_go//go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
## Summary

This change sets up VSCode settings to support editing Go files that are built using the Bazel build system.

Doing so is needed to support IDEs other than GoLand, which is paid only.
