### PR TITLE
Add buf plugin settings to global vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,6 @@
   "go.buildOnSave": "off",
   "go.lintOnSave": "off",
   "go.vetOnSave": "off",
-  "buf.commandLine.path": "/usr/local/bin/buf",
+  "buf.commandLine.path": "",
   "buf.log-format": "json"
 }


### PR DESCRIPTION
## Summary

This change updates the `buf` binary location and `buf` log format settings to JSON in the global VSCode settings.
