### PR TITLE
Increase the number of allowed PRs for Gradle dependency updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,3 +28,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
## Summary

This change increases the number of PRs Dependabot is allowed to open for Gradle dependencies from a default of 5 to 20.
